### PR TITLE
Htaccess for antora new folder

### DIFF
--- a/supplemental-ui/.htaccess
+++ b/supplemental-ui/.htaccess
@@ -1,25 +1,10 @@
 DirectoryIndex index.html index.asciidoc
 
-# former path to antora path
-Redirect 301 /about/ /front/main/about/
-Redirect 301 /blogs/ /front/main/blogs/
-Redirect 301 /jackpot/ /front/main/jackpot/
-Redirect 301 /community/ /front/main/community/
-Redirect 301 /help/ /front/main/help/
-Redirect 301 /projects/ /front/main/projects/
-Redirect 301 /participate/ /front/main/participate/
-Redirect 301 /kb/ /tutorial/main/kb/
-Redirect 301 /tutorials/ /tutorial/main/tutorial/
-Redirect 301 /wiki/ /wiki/main/wiki/
-
-
+# download from incubation
 Redirect 302 /download/9.0-beta/source https://archive.apache.org/dist/incubator/netbeans/incubating-netbeans-java/incubating-9.0-beta/incubating-netbeans-java-9.0-beta-source.zip
 Redirect 302 /download/9.0-beta/binary https://archive.apache.org/dist/incubator/netbeans/incubating-netbeans-java/incubating-9.0-beta/incubating-netbeans-java-9.0-beta-bin.zip
 
-# former path to antora path after letting download to 
-Redirect 301 /download/ /front/main/download/
-
-
+# old NetBeans updates center
 Redirect 301 /updates/8.2/uc/final/certified/catalog.xml.gz http://updates.netbeans.org/netbeans/updates/8.2/uc/final/certified/catalog.xml.gz
 
 # Inbound links from the IDE - prefixed with /nb/
@@ -62,8 +47,8 @@ Redirect 302 /nb/updates/19/ https://netbeans-vm1.apache.org/uc/19/
 Redirect 302 /nb/plugins/19/ https://plugins.netbeans.apache.org/data/19/
 Redirect 302 /nb/updates/dev/ https://netbeans-vm1.apache.org/uc/dev/
 Redirect 302 /nb/plugins/dev/ https://plugins.netbeans.apache.org/data/19/
-Redirect 302 /nb/issues_redirect.html https://netbeans.apache.org/participate/report-issue.html
-Redirect 302 /nb/report-issue https://netbeans.apache.org/participate/report-issue.html
+Redirect 302 /nb/issues_redirect.html https://netbeans.apache.org/front/main/participate/report-issue.html
+Redirect 302 /nb/report-issue https://netbeans.apache.org/front/main/participate/report-issue.html
 
 # Inbound links from the build - prefixed with /nbbuild/
 Redirect 302 /nbbuild/netbeansrelease.json https://raw.githubusercontent.com/apache/netbeans-jenkins-lib/HEAD/meta/netbeansrelease.json
@@ -71,8 +56,8 @@ Redirect 302 /nbbuild/netbeansrelease.json https://raw.githubusercontent.com/apa
 #cgi mirror script not needed
 #Redirect 301 /download/maven/index.html /download/maven/index.cgi
 
-# Redirect /kb/trails to /kb/docs antora path
-Redirect 301 /kb/trails /tutorial/main/kb/docs
+# Redirect /kb/trails to /kb/docs 
+Redirect 301 /kb/trails /kb/docs
 
 # Some other redirections
 Redirect 301 /features/ide/database.html /kb/docs/ide/#_databases
@@ -91,6 +76,20 @@ RedirectMatch 301 ^/.?downloads/.*$ /download/index.html
 
 # Redirect plugin page to plugin portal
 Redirect 302 /plugins/index.html https://plugins.netbeans.apache.org/
+
+# former path to antora path after letting download to 
+Redirect 301 /about/ /front/main/about/
+# should also redirect atom 
+Redirect 301 /blogs/ /front/main/blogs/
+Redirect 301 /jackpot/ /front/main/jackpot/
+Redirect 301 /community/ /front/main/community/
+Redirect 301 /help/ /front/main/help/
+Redirect 301 /projects/ /front/main/projects/
+Redirect 301 /participate/ /front/main/participate/
+Redirect 301 /kb/ /tutorial/main/kb/
+Redirect 301 /tutorials/ /tutorial/main/tutorial/
+Redirect 301 /wiki/ /wiki/main/wiki/
+Redirect 301 /download/ /front/main/download/
 
 # A simple error page to antora folder
 ErrorDocument 404 /front/main/404.html


### PR DESCRIPTION
Hi,
 trying to get antora ready if we wanna merge I think the htacess is the most mission critial file :p. And I cannot test it live.
 
 ns,dtds folder stay the same.

The files would be like that:
https://ci-builds.apache.org/job/Netbeans/job/netbeans-antora-website/lastSuccessfulBuild/artifact/site.zip
on the root folder there is a 10M of index for search lunr.

plugin, and update center redirect should stay the same.

The last part of redirect should handle all the former folder to new one. That's my expectations but I'm not sure. Handling the atom feed and former oracle netbeans folder to new antora folder.



