### PR TITLE
asciidoc extension to manage video

### DIFF
--- a/antora-local-playbook.yml
+++ b/antora-local-playbook.yml
@@ -10,7 +10,10 @@ antora:
   - require: ./lib/rssfeed.js
   - require: '@antora/lunr-extension'
     index_latest_only: true
-
+## asciidoc create new tag for video youtube + consent
+asciidoc:
+  extensions:
+  - ./lib/a-video
 content:
   sources:
   - url: ./../netbeans-antora-site/

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -11,7 +11,10 @@ antora:
   - require: ./lib/rssfeed.js
   - require: '@antora/lunr-extension'
     index_latest_only: true
-
+## asciidoc create new tag for video youtube + consent
+asciidoc:
+  extensions:
+  - ./lib/a-video
 content:
   sources:
   #- url: https://github.com/ebarboni/netbeans-antora-site.git

--- a/lib/a-video.js
+++ b/lib/a-video.js
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+'use strict'
+
+function avideo() {
+
+    const self = this
+    // should react on avideo::
+    self.named('avideo')
+    self.process(function (parent, target, attrs) {
+        // rewrite the youtube code as image (  get from  https://i1.ytimg.com/vi/<videocode>/hq1.jpg )
+        let imagetarget = './' + target + '.jpg'
+        // get and id
+        let idofvideoplaceholder = target + 'placeholder';
+
+        // prepare attribute list for image
+        let attribute = {'target': imagetarget, 'alt': 'placeholder for video ' + target}
+        // script to play on click
+        let script = `<script>
+        function loadScript() {
+            return new Promise((resolve, reject) => {
+                let script = document.createElement('script');
+                script.src = 'https://www.youtube.com/iframe_api';
+                script.addEventListener('load', resolve);
+                script.addEventListener('error', (e) => reject(e));
+                document.body.appendChild(script);
+            });
+        }
+
+        function addElement() {
+            loadScript().then(() => {
+                window.YT.ready(function() {
+                    let player = new YT.Player('${idofvideoplaceholder}', {
+                    height: '490',
+                    width: '968',
+                    videoId: '${target}',
+                    playerVars: {
+                        'playsinline': 1
+                    },
+                    events: {
+                        'onReady': (event) => {
+                            event.target.playVideo();
+                        }
+                    }
+                    });
+                });
+            });
+        }
+
+        var container = document.querySelector('#${idofvideoplaceholder} .content');
+        container.addEventListener('click', addElement);
+    </script>`
+
+        const nodes = []
+        // create div wrapper with id of video for the script to get the correct video
+        nodes.push(self.createBlock(parent, 'pass', `<div class="videoconsentblock" id="${idofvideoplaceholder}">`))
+        // get image should be local
+        // using block will trigger issue on image target not found
+        nodes.push(self.createBlock(parent, 'image', "", attribute))
+        nodes.push(self.createBlock(parent, 'pass', `</div>`))
+        // Apache privacy
+        nodes.push(self.createBlock(parent, 'paragraph', 'Clicking on the image above will load the video and send data from and to Googl'))
+        nodes.push(self.createBlock(parent, 'pass', script))
+        parent.blocks.push(...nodes)
+    })
+}
+
+
+module.exports.register = function register(registry) {
+    if (typeof registry.register === 'function') {
+        registry.register(function () {
+            this.blockMacro(avideo)
+        })
+    } else if (typeof registry.block === 'function') {
+        registry.blockMacro(avideo)
+    }
+    return registry
+}


### PR DESCRIPTION
Create a new tag for our site that permit generation of html that is compatible with privacy statement.
Video cannot be directly embedded and usr must consent before launching.

basicaly replace **video::** by **avideo::** 

Example here, on one page:

https://github.com/apache/netbeans-antora-site/pull/16/
Text at the bottom of the video can be shown on this screenshot
![image](https://github.com/apache/netbeans-antora/assets/6940099/c413d893-b3e5-4f59-a8fa-c35d5fce65ab)

I didn't yet tackle css stuff and the js is a bit brutal.

The generation try to use asciidoc itself to help resolving the image. (If we miss an image we have an error on antora level that help finding missing one)


Sidenote:
https://github.com/apache/netbeans-antora-site/pull/16/ contains image wget from this pattern https://i1.ytimg.com/vi/<videocode>/hq1.jpg I hope this is ok to server from our site.

In the current website video are blocked by **CSP**. This PR may allow to further customise our output if we need a link instead of embedded video.
