### PR TITLE
Configure empty update centre for NB26.

### DIFF
--- a/supplemental-ui/.htaccess
+++ b/supplemental-ui/.htaccess
@@ -64,6 +64,8 @@ Redirect 302 /nb/updates/24/ https://netbeans-vm1.apache.org/uc/24/
 Redirect 302 /nb/plugins/24/ https://plugins.netbeans.apache.org/data/24/
 Redirect 302 /nb/updates/25/ https://netbeans-vm1.apache.org/uc/25/
 Redirect 302 /nb/plugins/25/ https://plugins.netbeans.apache.org/data/25/
+Redirect 302 /nb/updates/26/ /updates/current.xml
+Redirect 302 /nb/plugins/26/ https://plugins.netbeans.apache.org/data/25/
 Redirect 302 /nb/updates/dev/ https://netbeans-vm1.apache.org/uc/dev/
 Redirect 302 /nb/plugins/dev/ https://plugins.netbeans.apache.org/data/25/
 # linked from ide.branding 

--- a/supplemental-ui/ui.yml
+++ b/supplemental-ui/ui.yml
@@ -8,3 +8,4 @@ static_files:
 - ns/ant-project-libraries/*
 - ns/j2se-project/*
 - ns/nb-module-project/*
+- updates/*

--- a/supplemental-ui/updates/current.xml
+++ b/supplemental-ui/updates/current.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!DOCTYPE module_updates PUBLIC "-//NetBeans//DTD Autoupdate Catalog 2.8//EN" "https://netbeans.apache.org/dtds/autoupdate-catalog-2_8.dtd">
+<module_updates timestamp="0/0/0/14/04/2025">
+</module_updates>

--- a/supplemental-ui/updates/previous.xml
+++ b/supplemental-ui/updates/previous.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!DOCTYPE module_updates PUBLIC "-//NetBeans//DTD Autoupdate Catalog 2.8//EN" "https://netbeans.apache.org/dtds/autoupdate-catalog-2_8.dtd">
+<module_updates timestamp="0/0/0/14/04/2025">
+  <notification url="https://netbeans.apache.org/download/index.html">Apache NetBeans IDE 25 is available!</notification>
+</module_updates>


### PR DESCRIPTION
Given current mailing list thread includes proposal to remove NBM publishing from release artefacts, we would need to serve an empty update centre to the IDE.  We could keep this all on the website, with `current.xml` used for latest release, and `previous.xml` used for older releases to keep the notification in one file.  If any release requires updates, a separate file (eg. `nb26.xml`) could be added in to updates, just linking to the updated NBMs for that release.