### PR TITLE
Adjust build instructions for local usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,26 @@ Several repository are used as content for the website:
 ### Building localy
 
 ```
+# replace username with your own github repository username if you want to use your own clones
+username=apache
 mkdir antora
 cd antora
-git clone https://github.com/<username>/netbeans-antora.git
-git clone https://github.com/<username>/netbeans-antora-site.git
-git clone https://github.com/<username>/netbeans-antora-wiki.git
-git clone https://github.com/<username>/netbeans-antora-tutorials.git
-git clone https://github.com/<username>/netbeans-antora-ui.git
+git clone https://github.com/$username/netbeans-antora.git
+git clone https://github.com/$username/netbeans-antora-site.git
+git clone https://github.com/$username/netbeans-antora-wiki.git
+git clone https://github.com/$username/netbeans-antora-tutorials.git
+git clone https://github.com/$username/netbeans-antora-ui.git
+# Build the netbeans-antora-ui project first
+cd netbeans-antora-ui
+npm install
+npm run gulp bundle
+# Install required extension and launch local build
 cd netbeans-antora
+npm install
 npx antora antora-local-playbook.yml
+# Launch local webserver the provided file:// url from antora build does not work
+# nicely with directory links, that expect the index.html to open
+npx http-server build/site
 ```
 
 ## Apache guidelines for web sites


### PR DESCRIPTION
- simplify getting started by cloning from apache repostories
- document requirement to build netbeans-antora-ui
- add missing npm install step for netbeans-antora
- provide instructions to launch a local http server