### PR TITLE
Update .htaccess for NB29 plugins

### DIFF
--- a/supplemental-ui/.htaccess
+++ b/supplemental-ui/.htaccess
@@ -64,11 +64,11 @@ Redirect 302 /nb/plugins/27/ https://plugins.netbeans.apache.org/data/27/
 Redirect 302 /nb/updates/28/updates.xml /updates/current.xml
 Redirect 302 /nb/plugins/28/ https://plugins.netbeans.apache.org/data/28/
 Redirect 302 /nb/updates/29/updates.xml /updates/current.xml
-Redirect 302 /nb/plugins/29/ https://plugins.netbeans.apache.org/data/28/
+Redirect 302 /nb/plugins/29/ https://plugins.netbeans.apache.org/data/29/
 # dev builds including temporary gz redirect
 Redirect 302 /nb/updates/dev/updates.xml /updates/current.xml
 Redirect 302 /nb/updates/dev/updates.xml.gz /updates/current.xml
-Redirect 302 /nb/plugins/dev/ https://plugins.netbeans.apache.org/data/28/
+Redirect 302 /nb/plugins/dev/ https://plugins.netbeans.apache.org/data/29/
 # linked from ide.branding 
 Redirect 302 /nb/issues.html https://netbeans.apache.org/front/main/participate/report-issue/
 Redirect 302 /nb/issues_redirect.html https://netbeans.apache.org/front/main/participate/report-issue/


### PR DESCRIPTION
Update plugins for NB29 and dev from NB28 portal.

Normally with rc3 but as we skipped an rc should happen now.