### PR TITLE
Update plugin redirect URLs for NB30 release

### DIFF
--- a/supplemental-ui/.htaccess
+++ b/supplemental-ui/.htaccess
@@ -67,11 +67,11 @@ Redirect 302 /nb/plugins/28/ https://plugins.netbeans.apache.org/data/28/
 Redirect 302 /nb/updates/29/updates.xml /updates/current.xml
 Redirect 302 /nb/plugins/29/ https://plugins.netbeans.apache.org/data/29/
 Redirect 302 /nb/updates/30/updates.xml /updates/current.xml
-Redirect 302 /nb/plugins/30/ https://plugins.netbeans.apache.org/data/29/
+Redirect 302 /nb/plugins/30/ https://plugins.netbeans.apache.org/data/30/
 # dev builds including temporary gz redirect
 Redirect 302 /nb/updates/dev/updates.xml /updates/current.xml
 Redirect 302 /nb/updates/dev/updates.xml.gz /updates/current.xml
-Redirect 302 /nb/plugins/dev/ https://plugins.netbeans.apache.org/data/29/
+Redirect 302 /nb/plugins/dev/ https://plugins.netbeans.apache.org/data/30/
 # linked from ide.branding 
 Redirect 302 /nb/issues.html https://netbeans.apache.org/front/main/participate/report-issue/
 Redirect 302 /nb/issues_redirect.html https://netbeans.apache.org/front/main/participate/report-issue/


### PR DESCRIPTION
Update the plugins redirect for NB30.  Noticed this was still pointing to NB29 while testing the vote candidate.